### PR TITLE
Bugfix: uninitialized parent wrapproperties

### DIFF
--- a/Tests/WrapModelTests.swift
+++ b/Tests/WrapModelTests.swift
@@ -403,14 +403,9 @@ class WrapModelTests: XCTestCase {
                     XCTAssert(false, "Unable to convert string to date with type \(dateType) and string \(dateStr)")
                 }
                 
-                // All other date types should be able to convert back with fallback allowed
+                // Make sure with fallbacks we manage to convert string into a valid date
                 for dateType2 in WrapPropertyDate.DateOutputType.allCases {
-                    if let convDate2 = dateType2.date(from: dateStr, fallbackToOtherFormats: true) {
-                        let convDateStr2 = dateType.string(from: convDate2) // orig date type to convert back to string
-                        XCTAssertEqual(dateStr, convDateStr2)
-                    } else {
-                        XCTAssert(false, "Unable to convert string to date with type \(dateType2) and string \(dateStr)")
-                    }
+                    XCTAssertNotNil(dateType2.date(from: dateStr, fallbackToOtherFormats: true), "Unable to convert string to date even with fallback output options")
                 }
             } else {
                 XCTAssert(false, "Unable to convert date to string with type \(dateType)")

--- a/Tests/WrapModelTests.swift
+++ b/Tests/WrapModelTests.swift
@@ -965,6 +965,48 @@ class WrapModelTests: XCTestCase {
         XCTAssertEqual(mWyatt, wyattCopy)
         XCTAssertTrue(wyattCopy.isEqualToModel(model:mWyatt))
     }
+    
+    
+    func testWrapPropertyInheritance() {
+        
+        class User: WrapModel {
+            let _id = WPOptInt("id")
+            let _token = WPOptStr("token")
+            
+            var id: Int? { return _id.value }
+            var token: String? { return _token.value }
+        }
+        
+        class Seller: User {
+            let _logoPath = WPOptStr("logoPath")
+            
+            var logoPath: String? { return _logoPath.value }
+        }
+        
+        let sellerFromDict = Seller(data: [
+            "id": 5,
+            "token": "abcde",
+            "logoPath": "/stuff.jpg"
+        ], mutable: false)
+        
+        
+        // Seller subclass should initialize WrapProperties from its super class correctly:
+        XCTAssertEqual(sellerFromDict.id, 5)
+        XCTAssertEqual(sellerFromDict.token, "abcde")
+        XCTAssertEqual(sellerFromDict.logoPath, "/stuff.jpg")
+
+        
+        let sellerCopy = sellerFromDict.copy() as! Seller
+        XCTAssertEqual(sellerCopy.id, 5)
+        XCTAssertEqual(sellerCopy.token, "abcde")
+        XCTAssertEqual(sellerCopy.logoPath, "/stuff.jpg")
+        
+        let sellerMutableCopy = sellerFromDict.mutableCopy() as! Seller
+        XCTAssertEqual(sellerMutableCopy.id, 5)
+        XCTAssertEqual(sellerMutableCopy.token, "abcde")
+        XCTAssertEqual(sellerMutableCopy.logoPath, "/stuff.jpg")
+        
+    }
 
 }
 

--- a/WrapModel/WrapModel.swift
+++ b/WrapModel/WrapModel.swift
@@ -1309,7 +1309,7 @@ public extension Dictionary where Value:Hashable {
 
 extension Mirror {
     
-    /// Collects the mirror's and all its parent mirror's children into one array
+    /// Collects the mirror's children and all its parents' mirror's children into one array
     func allChildren() -> [Mirror.Child] {
         var all = Array(self.children)
         

--- a/WrapModel/WrapModel.swift
+++ b/WrapModel/WrapModel.swift
@@ -83,21 +83,21 @@ open class WrapModel : NSObject, NSCopying, NSMutableCopying, NSCoding {
         
         // Get property references
         let mirror = Mirror(reflecting: self)
-        properties.reserveCapacity(mirror.children.count)
-        for prop in mirror.children {
+        properties = mirror.allChildren().compactMap { (prop) -> AnyWrapProperty? in
             switch prop.value {
             case let optionalObj as Optional<Any>:
                 switch optionalObj {
                 case .some(let innerObj):
                     if let wrapProp = innerObj as? AnyWrapProperty {
-                        properties.append(wrapProp)
+                        return wrapProp
                     }
                 case .none:
-                    break
+                    return nil
                 }
             }
+            return nil
         }
-        
+
         // Give each property a reference back to the model object
         properties.forEach { $0.model = self }
     }
@@ -1304,5 +1304,21 @@ public extension Dictionary where Value:Hashable {
             invDict[val] = key
         }
         return invDict
+    }
+}
+
+extension Mirror {
+    
+    /// Collects the mirror's and all its parent mirror's children into one array
+    func allChildren() -> [Mirror.Child] {
+        var all = Array(self.children)
+        
+        var parentMirror = self.superclassMirror
+        while let parent = parentMirror {
+            all.append(contentsOf: parent.children)
+            parentMirror = parent.superclassMirror
+        }
+        
+        return all
     }
 }


### PR DESCRIPTION
Fixes a bug where subclasses did not initialize `WrapProperty` instances defined in their parents. When initializing a WrapModel subclass, we will now collect the parent's (and parent's parents)  children along with the current object's children and make sure all WrapProperty's are property initialized. 