### PR TITLE
Fix an issue with copying models with different mutable status

### DIFF
--- a/Tests/WrapModelTests.swift
+++ b/Tests/WrapModelTests.swift
@@ -937,6 +937,23 @@ class WrapModelTests: XCTestCase {
     
     func testMutableCopy() throws {
         
+        // Access a submodel that we'll check for mutability
+        // submodel of mutable copy should also be mutable
+        let _ = wyatt.currentPurchase
+        let wyattMutableCopy = wyatt.mutableCopy() as! SampleModel
+        XCTAssertTrue(wyattMutableCopy.currentPurchase?.isMutable ?? false)
+        
+        // Now check that a submodel in an immutable copy of a mutable model is immutable
+        let _ = mWyatt.currentPurchase
+        let wyattImmutableCopy = mWyatt.copy() as! SampleModel
+        XCTAssertFalse(wyattImmutableCopy.currentPurchase?.isMutable ?? true)
+        
+        // Check the same things creating copies using initializer
+        let wyattMutableCopy2 = SampleModel(asCopyOf: wyatt, withMutations: true, mutable: true)
+        XCTAssertTrue(wyattMutableCopy2.currentPurchase?.isMutable ?? false)
+        let wyattImmutableCopy2 = SampleModel(asCopyOf: mWyatt, withMutations: true, mutable: false)
+        XCTAssertFalse(wyattImmutableCopy2.currentPurchase?.isMutable ?? true)
+
         // copy the model and test that it is the same as the original
         let wyattCopy = SampleModel(asCopyOf: mWyatt, withMutations: false, mutable: true)
         XCTAssertEqual(mWyatt, wyattCopy)

--- a/WrapModel/WrapModel.swift
+++ b/WrapModel/WrapModel.swift
@@ -985,6 +985,8 @@ public class WrapPropertyBool: WrapProperty<Bool> {
 fileprivate func intFromAny(_ val:Any) -> Int? {
     if let dblVal = val as? Double {
         return Int(dblVal.rounded())
+    } else if let fltVal = val as? Float {
+        return Int(fltVal.rounded())
     } else if let intVal = val as? Int {
         return intVal
     } else if let strVal = val as? String {
@@ -1000,6 +1002,8 @@ fileprivate func intFromAny(_ val:Any) -> Int? {
 fileprivate func floatFromAny(_ val:Any) -> Float? {
     if let dblVal = val as? Double {
         return Float(dblVal)
+    } else if let fltVal = val as? Float {
+        return fltVal
     } else if let strVal = val as? String {
         return Float(strVal)
     } else if let intVal = val as? Int {
@@ -1011,6 +1015,8 @@ fileprivate func floatFromAny(_ val:Any) -> Float? {
 fileprivate func doubleFromAny(_ val:Any) -> Double? {
     if let dblVal = val as? Double {
         return dblVal
+    } else if let fltVal = val as? Float {
+        return Double(fltVal)
     } else if let strVal = val as? String {
         return Double(strVal)
     } else if let intVal = val as? Int {

--- a/WrapModel/WrapModel.swift
+++ b/WrapModel/WrapModel.swift
@@ -465,13 +465,13 @@ public protocol WrapConvertibleEnum: RawRepresentable, Hashable where RawValue =
 }
 
 public extension WrapConvertibleEnum {
-    public func stringValue() -> String? {
+    func stringValue() -> String? {
         return type(of: self).stringValue(from: self)
     }
-    public static func stringValue(from:Self) -> String? {
+    static func stringValue(from:Self) -> String? {
         return conversionDict().inverted()[from]
     }
-    public var hashValue:Int {
+    var hashValue:Int {
         return rawValue.hashValue
     }
 }


### PR DESCRIPTION
Copying a model was being accomplished by created a new model using the original data dictionary and copying cached values/mutations. In the case of submodels, this could result in submodels with a different mutable status than the parent.

Also, explicitly check for Float types - they don't automatically cast as Doubles.

Added some tests around model copying and submodel mutability.