### PR TITLE
BA-5668 minor fixes/improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 Changes in reverse chronological order
 <hr>
 
+### Version 1.3.5 - 26 Jan 2024
+
+- Minor lock efficiency update
+
 ### Version 1.3.4 - 14 Apr 2022
 
 - Added Swift Package Manager support

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018-2019 1stdibs.com
+Copyright (c) 2018-2024 1stdibs.com
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Sources/WrapModel/WrapModel.swift
+++ b/Sources/WrapModel/WrapModel.swift
@@ -171,7 +171,7 @@ open class WrapModel : NSObject, NSCopying, NSMutableCopying, NSCoding {
     private var contributedLock:WrapModelLock?
     private var cacheLock = WrapModelLock()
     private var cacheLockLock = WrapModelLock()
-    private lazy var cachedValues = [String:Any].init(minimumCapacity: self.properties.count)
+    private lazy var cachedValues = [String:Any]()
     fileprivate func getCached(forProperty property:AnyWrapProperty) -> Any? {
         return lock.reading {
             return self.cachedValues[property.keyPath]

--- a/Sources/WrapModel/WrapModelLock.swift
+++ b/Sources/WrapModel/WrapModelLock.swift
@@ -22,8 +22,8 @@ public final class WrapModelLock {
         }
     }
     
-    func writing(_ block:@escaping ()->Void) {
-        queue.async(flags: .barrier) {
+    func writing(_ block:()->Void) {
+        queue.sync(flags: .barrier) {
             block()
         }
     }

--- a/Sources/WrapModel/WrapModelLock.swift
+++ b/Sources/WrapModel/WrapModelLock.swift
@@ -13,11 +13,7 @@ public final class WrapModelLock {
     private let queue:DispatchQueue
     
     init() {
-        queue = WrapModelDispatchQueueRecycler.queue()
-    }
-    
-    deinit {
-        WrapModelDispatchQueueRecycler.recycle(queue: queue)
+        queue = DispatchQueue(label: "WrapModel cache", qos: .userInitiated, attributes: .concurrent)
     }
     
     func reading<T>(_ block:()->T) -> T {
@@ -26,51 +22,9 @@ public final class WrapModelLock {
         }
     }
     
-    func writing(_ block:()->Void) {
-        queue.sync(flags: .barrier) {
+    func writing(_ block:@escaping ()->Void) {
+        queue.async(flags: .barrier) {
             block()
         }
     }
 }
-
-/// A private class used to manage a pool of recycled WrapModelLocks
-fileprivate class WrapModelDispatchQueueRecycler {
-    private static var queuePool = [DispatchQueue]()
-    private static let poolLock = DispatchQueue(label: "WrapModelDispatchQueueRecycler pool")
-    #if DEBUG
-    private static var queuesCreated = 0
-    private static var activeQueues = 0
-    #endif
-    
-    fileprivate class func queue() -> DispatchQueue {
-        return poolLock.sync {
-            #if DEBUG
-            activeQueues += 1
-            #endif
-            let q:DispatchQueue
-            if !queuePool.isEmpty {
-                q = queuePool.removeLast()
-            } else {
-                #if DEBUG
-                queuesCreated += 1
-                #endif
-                q = DispatchQueue(label: "WrapModel cache", qos: .userInitiated, attributes: .concurrent)
-            }
-            #if DEBUG
-//            print("WrapModel lock recycler: \(activeQueues) active queues of total \(queuesCreated) created")
-            #endif
-            return q
-        }
-    }
-    
-    fileprivate class func recycle(queue:DispatchQueue) {
-        poolLock.sync {
-            #if DEBUG
-            activeQueues -= 1
-//            print("WrapModel lock recycler: \(activeQueues) active queues of total \(queuesCreated) created")
-            #endif
-            queuePool.append(queue)
-        }
-    }
-}
-

--- a/WrapModel.podspec
+++ b/WrapModel.podspec
@@ -2,7 +2,7 @@ Pod::Spec.new do |s|
 
 s.name = "WrapModel"
 s.summary = "WrapModel is a data model class providing access to JSON formatted model data in string or dictionary form."
-s.version = "1.3.4"
+s.version = "1.3.5"
 
 # Requirements
 s.platform = :ios


### PR DESCRIPTION
https://1stdibs.atlassian.net/browse/BA-5668

- WrapModel refrains from accessing other object properties during lazy creation of cached values dictionary - it's possible this has been crashing apps at startup
- Removed unnecessary dispatch queue recycling mechanism. It provides no noticeable difference and dispatch queues are supposed to be, by their nature, very lightweight and shouldn't need the overhead of the extra locking this was doing.
- updates library version to 1.3.5, and updates release history